### PR TITLE
fix: trigger onMapReady after map state has updated

### DIFF
--- a/packages/react-native-web-maps/src/components/map-view.tsx
+++ b/packages/react-native-web-maps/src/components/map-view.tsx
@@ -52,10 +52,15 @@ function _MapView(props: MapViewProps, ref: ForwardedRef<Partial<RNMapView>>) {
   const _onMapReady = useCallback(
     (_map: google.maps.Map) => {
       setMap(_map);
-      props.onMapReady?.();
     },
     [map, props.onMapReady]
   );
+
+  useEffect(() => {
+    if (map) {
+      props.onMapReady?.();
+    }
+  }, [map]);
 
   const _onDragStart = useCallback(() => {
     setIsGesture(true);


### PR DESCRIPTION
If props.onMapReady is called immediately after setMap then a method
called in props.onMapReady such as fitToCoordinates may not work 
correctly since map is still null.

Using an effect to trigger props.onMapReady means that by the time
props.onMapReady is triggered MapView is ready not just the underlying
GoogleMap.