### PR TITLE
fix src import

### DIFF
--- a/packages/react-native-web-maps/src/components/marker-clusterer/marker-clusterer.tsx
+++ b/packages/react-native-web-maps/src/components/marker-clusterer/marker-clusterer.tsx
@@ -1,7 +1,7 @@
 import type { ClusterProps, MarkerClustererProps } from './types';
 
 import React, { memo, ReactElement, useMemo, useState } from 'react';
-import { getBoundByRegion } from '@teovilla/react-native-web-maps/src/utils/region';
+import { getBoundByRegion } from '../../utils/region';
 import type { MarkerProps } from 'react-native-maps';
 import { Cluster } from './cluster';
 import Supercluster from 'supercluster';


### PR DESCRIPTION
fix for #8 and #12

```shell
error - ../../node_modules/@teovilla/react-native-web-maps/src/utils/region.ts
Module parse failed: Unexpected token (1:12)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> import type { BBox } from 'geojson';
| import type { Region } from 'react-native-maps';
|

Import trace for requested module:
../../node_modules/@teovilla/react-native-web-maps/src/utils/region.ts
../../node_modules/@teovilla/react-native-web-maps/dist/module/components/marker-clusterer/marker-clusterer.js
../../node_modules/@teovilla/react-native-web-maps/dist/module/components/marker-clusterer/index.js
../../node_modules/@teovilla/react-native-web-maps/dist/module/index.web.js
../../packages/app/features/home/screen.tsx
```