### PR TITLE
feat: Add support for Callout component

### DIFF
--- a/docs/docs/support/callout.md
+++ b/docs/docs/support/callout.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Callout 🤔
+title: Callout ✅
 ---
 
 ## Legend
@@ -10,4 +10,17 @@ title: Callout 🤔
 - Needs investigation 🤔
 - Planned 🌲
 
-This component is currently not supported, I still have to look at it since I've never used it before so I don't know really what's used for. I think that this can be created without using a component from the web API but instead making it from scratch. (should be easy)
+## Props
+
+| Prop           | Status |
+| -------------- | ------ |
+| `tooltip`      | ✅     |
+| `alphaHitTest` | ❌     |
+
+## Events
+
+To access event data, you will need to use `e.nativeEvent`. For example, `onPress={e => console.log(e.nativeEvent)}` will log the entire event object to your console.
+
+| Event Name | Status |
+| ---------- | ------ |
+| `onPress`  | ✅     |

--- a/docs/docs/support/marker.md
+++ b/docs/docs/support/marker.md
@@ -23,7 +23,7 @@ title: Marker ✅
 | `centerOffset`            | 🤔     |
 | `calloutOffset`           | 🤔     |
 | `anchor`                  | ✅     |
-| `calloutAnchor`           | 🤔     |
+| `calloutAnchor`           | ✅     |
 | `flat`                    | ❌     |
 | `identifier`              | ❌     |
 | `rotation`                | ❌     |
@@ -54,8 +54,8 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 
 | Method Name                 | Status |
 | --------------------------- | ------ |
-| `showCallout`               | ❌     |
-| `hideCallout`               | ❌     |
+| `showCallout`               | ✅     |
+| `hideCallout`               | ✅     |
 | `redrawCallout`             | ❌     |
 | `animateMarkerToCoordinate` | ❌     |
 | `redraw`                    | ❌     |

--- a/packages/react-native-web-maps/src/components/callout.tsx
+++ b/packages/react-native-web-maps/src/components/callout.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {
+  InfoWindow as GMInfoWindow,
+  OverlayView as GMOverlayView,
+  useGoogleMap,
+} from '@react-google-maps/api';
+import type { MapCalloutProps, LatLng } from 'react-native-maps';
+import { mapMouseEventToMapEvent } from '../utils/mouse-event';
+
+export type CalloutContextType = {
+  coordinate: LatLng;
+  calloutVisible: boolean;
+  toggleCalloutVisible: () => void;
+  mvcObjectAnchor?: google.maps.MVCObject;
+};
+
+export const CalloutContext = React.createContext<CalloutContextType>({
+  coordinate: { latitude: 0, longitude: 0 },
+  calloutVisible: false,
+  toggleCalloutVisible: () => {},
+});
+
+export function Callout(props: MapCalloutProps) {
+  const map = useGoogleMap();
+
+  const { coordinate, calloutVisible, toggleCalloutVisible, mvcObjectAnchor } =
+    React.useContext(CalloutContext);
+
+  return calloutVisible ? (
+    <div
+      onClick={() =>
+        props.onPress?.(
+          mapMouseEventToMapEvent(null, coordinate, map, 'callout-press')
+        )
+      }
+    >
+      {props.tooltip ? (
+        <GMOverlayView
+          mapPaneName="overlayMouseTarget"
+          position={{
+            lat: Number(coordinate.latitude),
+            lng: Number(coordinate.longitude),
+          }}
+        >
+          <>{props.children}</>
+        </GMOverlayView>
+      ) : (
+        <GMInfoWindow
+          anchor={mvcObjectAnchor}
+          position={{
+            lat: Number(coordinate.latitude),
+            lng: Number(coordinate.longitude),
+          }}
+          onCloseClick={() => toggleCalloutVisible()}
+        >
+          <>{props.children}</>
+        </GMInfoWindow>
+      )}
+    </div>
+  ) : null;
+}

--- a/packages/react-native-web-maps/src/components/callout.tsx
+++ b/packages/react-native-web-maps/src/components/callout.tsx
@@ -4,35 +4,50 @@ import {
   OverlayView as GMOverlayView,
   useGoogleMap,
 } from '@react-google-maps/api';
-import type { MapCalloutProps, LatLng } from 'react-native-maps';
+import type { MapCalloutProps, LatLng, Point } from 'react-native-maps';
 import { mapMouseEventToMapEvent } from '../utils/mouse-event';
 
 export type CalloutContextType = {
   coordinate: LatLng;
   calloutVisible: boolean;
   toggleCalloutVisible: () => void;
-  mvcObjectAnchor?: google.maps.MVCObject;
+  markerSize: { width: number; height: number };
+  anchor: Point;
 };
 
 export const CalloutContext = React.createContext<CalloutContextType>({
   coordinate: { latitude: 0, longitude: 0 },
   calloutVisible: false,
   toggleCalloutVisible: () => {},
+  markerSize: { width: 0, height: 0 },
+  anchor: { x: 0, y: 0 },
 });
 
 export function Callout(props: MapCalloutProps) {
   const map = useGoogleMap();
 
-  const { coordinate, calloutVisible, toggleCalloutVisible, mvcObjectAnchor } =
-    React.useContext(CalloutContext);
+  const {
+    coordinate,
+    calloutVisible,
+    toggleCalloutVisible,
+    markerSize,
+    anchor,
+  } = React.useContext(CalloutContext);
+
+  //By default callout is positioned to bottom center
+  //i.e. is at anchor: (0.5, 1)
+  //This compensates to match expected result using the provided anchor prop
+  const xOffset = -(markerSize.width * (0.5 - anchor.x));
+  const yOffset = -(markerSize.height * (1 - anchor.y));
 
   return calloutVisible ? (
     <div
-      onClick={() =>
+      onClick={(e) => {
         props.onPress?.(
           mapMouseEventToMapEvent(null, coordinate, map, 'callout-press')
-        )
-      }
+        );
+        e.stopPropagation(); //Prevent marker click handler from being called
+      }}
     >
       {props.tooltip ? (
         <GMOverlayView
@@ -41,15 +56,24 @@ export function Callout(props: MapCalloutProps) {
             lat: Number(coordinate.latitude),
             lng: Number(coordinate.longitude),
           }}
+          getPixelPositionOffset={() => ({
+            x: xOffset,
+            y: yOffset,
+          })}
         >
-          <>{props.children}</>
+          {/* Render on top of marker instead of inside */}
+          <div style={{ transform: 'translate(-50%,-100%)' }}>
+            {props.children}
+          </div>
         </GMOverlayView>
       ) : (
         <GMInfoWindow
-          anchor={mvcObjectAnchor}
           position={{
             lat: Number(coordinate.latitude),
             lng: Number(coordinate.longitude),
+          }}
+          options={{
+            pixelOffset: new google.maps.Size(xOffset, yOffset),
           }}
           onCloseClick={() => toggleCalloutVisible()}
         >

--- a/packages/react-native-web-maps/src/components/marker.tsx
+++ b/packages/react-native-web-maps/src/components/marker.tsx
@@ -4,7 +4,7 @@ import {
   OverlayView as GMOverlayView,
   useGoogleMap,
 } from '@react-google-maps/api';
-import type { MarkerProps } from 'react-native-maps';
+import type { MarkerProps, Point } from 'react-native-maps';
 import { mapMouseEventToMapEvent } from '../utils/mouse-event';
 import { CalloutContext, CalloutContextType } from './callout';
 
@@ -37,6 +37,8 @@ export function Marker(props: MarkerProps) {
     [props.children]
   );
 
+  const anchor: Point = props.anchor || { x: 0.5, y: 1 };
+
   return (
     <CalloutContext.Provider value={calloutContextValue}>
       <>
@@ -47,14 +49,10 @@ export function Marker(props: MarkerProps) {
               lat: Number(props.coordinate.latitude),
               lng: Number(props.coordinate.longitude),
             }}
-            getPixelPositionOffset={
-              props.anchor
-                ? (w, h) => ({
-                    x: -(w * props.anchor!.x),
-                    y: -(h * props.anchor!.y),
-                  })
-                : undefined
-            }
+            getPixelPositionOffset={(w, h) => ({
+              x: -(w * anchor!.x),
+              y: -(h * anchor!.y),
+            })}
             onLoad={(overlayView) => setMvcObjectAnchor(overlayView)}
           >
             <div onClick={() => onMarkerPress()}>{props.children}</div>

--- a/packages/react-native-web-maps/src/components/marker.tsx
+++ b/packages/react-native-web-maps/src/components/marker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import {
   Marker as GMMarker,
   OverlayView as GMOverlayView,
@@ -6,68 +6,96 @@ import {
 } from '@react-google-maps/api';
 import type { MarkerProps } from 'react-native-maps';
 import { mapMouseEventToMapEvent } from '../utils/mouse-event';
+import { CalloutContext, CalloutContextType } from './callout';
 
 export function Marker(props: MarkerProps) {
   const map = useGoogleMap();
 
-  return props.children ? (
-    <GMOverlayView
-      mapPaneName="overlayMouseTarget"
-      position={{
-        lat: Number(props.coordinate.latitude),
-        lng: Number(props.coordinate.longitude),
-      }}
-      getPixelPositionOffset={
-        props.anchor
-          ? (w, h) => ({
-              x: -(w * props.anchor!.x),
-              y: -(h * props.anchor!.y),
-            })
-          : undefined
-      }
-    >
-      <div
-        onClick={() =>
-          props.onPress?.(
-            mapMouseEventToMapEvent(null, props.coordinate, map, 'marker-press')
-          )
-        }
-      >
-        {props.children}
-      </div>
-    </GMOverlayView>
-  ) : (
-    <GMMarker
-      draggable={props.draggable}
-      title={props.title}
-      onClick={(e) =>
-        props.onPress?.(
-          mapMouseEventToMapEvent(e, props.coordinate, map, 'marker-press')
-        )
-      }
-      onDrag={(e) =>
-        props.onDrag?.(mapMouseEventToMapEvent(e, props.coordinate, map, ''))
-      }
-      onDragStart={(e) =>
-        props.onDragStart?.(
-          mapMouseEventToMapEvent(e, props.coordinate, map, '')
-        )
-      }
-      onDragEnd={(e) =>
-        props.onDragEnd?.(mapMouseEventToMapEvent(e, props.coordinate, map, ''))
-      }
-      options={{
-        clickable: props.tappable,
-        opacity: props.opacity,
-        draggable: props.draggable,
-        anchorPoint: props.anchor
-          ? new google.maps.Point(props.anchor?.x, props.anchor?.y)
-          : null,
-      }}
-      position={{
-        lat: Number(props.coordinate.latitude),
-        lng: Number(props.coordinate.longitude),
-      }}
-    />
+  const [calloutVisible, setCalloutVisible] = React.useState(false);
+  const [mvcObjectAnchor, setMvcObjectAnchor] =
+    React.useState<google.maps.MVCObject>();
+
+  const onMarkerPress = (e?: google.maps.MapMouseEvent) => {
+    props.onPress?.(
+      mapMouseEventToMapEvent(e, props.coordinate, map, 'marker-press')
+    );
+    setCalloutVisible(!calloutVisible);
+  };
+
+  const calloutContextValue: CalloutContextType = {
+    calloutVisible,
+    toggleCalloutVisible: () => setCalloutVisible(!calloutVisible),
+    coordinate: props.coordinate,
+    mvcObjectAnchor,
+  };
+
+  const hasNonCalloutChildren = React.useMemo(
+    () =>
+      !!React.Children.toArray(props.children).find((child) => {
+        return ((child as ReactElement).type as Function).name !== 'Callout';
+      }),
+    [props.children]
+  );
+
+  return (
+    <CalloutContext.Provider value={calloutContextValue}>
+      <>
+        {hasNonCalloutChildren ? (
+          <GMOverlayView
+            mapPaneName="overlayMouseTarget"
+            position={{
+              lat: Number(props.coordinate.latitude),
+              lng: Number(props.coordinate.longitude),
+            }}
+            getPixelPositionOffset={
+              props.anchor
+                ? (w, h) => ({
+                    x: -(w * props.anchor!.x),
+                    y: -(h * props.anchor!.y),
+                  })
+                : undefined
+            }
+            onLoad={(overlayView) => setMvcObjectAnchor(overlayView)}
+          >
+            <div onClick={() => onMarkerPress()}>{props.children}</div>
+          </GMOverlayView>
+        ) : (
+          <GMMarker
+            draggable={props.draggable}
+            title={props.title}
+            onClick={(e) => onMarkerPress(e)}
+            onDrag={(e) =>
+              props.onDrag?.(
+                mapMouseEventToMapEvent(e, props.coordinate, map, '')
+              )
+            }
+            onDragStart={(e) =>
+              props.onDragStart?.(
+                mapMouseEventToMapEvent(e, props.coordinate, map, '')
+              )
+            }
+            onDragEnd={(e) =>
+              props.onDragEnd?.(
+                mapMouseEventToMapEvent(e, props.coordinate, map, '')
+              )
+            }
+            onLoad={(marker) => setMvcObjectAnchor(marker)}
+            options={{
+              clickable: props.tappable,
+              opacity: props.opacity,
+              draggable: props.draggable,
+              anchorPoint: props.anchor
+                ? new google.maps.Point(props.anchor?.x, props.anchor?.y)
+                : null,
+            }}
+            position={{
+              lat: Number(props.coordinate.latitude),
+              lng: Number(props.coordinate.longitude),
+            }}
+            children={props.children}
+          />
+        )}
+      </>
+    </CalloutContext.Provider>
   );
 }

--- a/packages/react-native-web-maps/src/index.web.tsx
+++ b/packages/react-native-web-maps/src/index.web.tsx
@@ -1,6 +1,7 @@
 export { MapView as default } from './components/map-view';
 export { Polygon } from './components/polygon';
 export { Marker } from './components/marker';
+export { Callout } from './components/callout';
 export { Polyline } from './components/polyline';
 export { Circle } from './components/circle';
 export { Geojson } from './components/geojson';


### PR DESCRIPTION
Hey. Great work on this package! It's really amazing and long overdue.

I'm part of the [Draftbit](https://draftbit.com/) team and this will be a great addition to our component selection. The one thing we needed that was missing was the `Callout` component. This PR adds that component + some changes to `Marker` to accommodate the `Callout`

## Screenshots
### Default/Simple Callout
| On default marker | On custom marker |
|---------------------|-----------------------|
|![Screenshot_2](https://user-images.githubusercontent.com/58384527/229744680-1ccd7aeb-19a1-4fca-9ac0-4a3df56b90f1.png)|![Screenshot_1](https://user-images.githubusercontent.com/58384527/229744823-0cec6020-bc24-4678-82d0-5b822407954c.png)|

### With `tooltip` enabled
| On default marker | On custom marker |
|---------------------|-----------------------|
|![Screenshot_4](https://user-images.githubusercontent.com/58384527/229745071-b220deae-b877-4dd5-94ef-144d2df658a5.png)|![Screenshot_3](https://user-images.githubusercontent.com/58384527/229745105-a118be65-22e1-4f68-85dc-9bb06baea407.png)|

### With custom `calloutAnchor`
| On default marker | On custom marker |
|---------------------|-----------------------|
|![Screenshot_6](https://user-images.githubusercontent.com/58384527/229745283-5f05bafa-5f70-4123-941b-ba6852ac33d1.png)*|![Screenshot_5](https://user-images.githubusercontent.com/58384527/229745330-9f152b16-10e0-4146-8297-8d11eaa15304.png)|
|*callout is covering the marker||

## Summary of changes
- Added `Callout` component
- Updated `Marker` to use default anchor (0.5,1)
- Updated `Marker` to support `calloutAnchor` prop
- Wrapped `Marker` in a class component to support `showCallout` and `hideCallout`
- Updated `Marker` to support `Callout` by passing down a context with callout specific data
- Updated docs 'supported list'




