### PR TITLE
chore: move jest-expo from `dependencies` to `devDependencies`

### DIFF
--- a/packages/react-native-web-maps/package.json
+++ b/packages/react-native-web-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teovilla/react-native-web-maps",
-  "version": "0.9.3",
+  "version": "0.9.2",
   "description": "Cross platform maps for react & react-native",
   "main": "dist/commonjs/index",
   "module": "dist/module/index",

--- a/packages/react-native-web-maps/package.json
+++ b/packages/react-native-web-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teovilla/react-native-web-maps",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Cross platform maps for react & react-native",
   "main": "dist/commonjs/index",
   "module": "dist/module/index",
@@ -52,6 +52,7 @@
     "@types/supercluster": "^7.1.0",
     "jest": "^29.2.1",
     "jest-environment-jsdom": "^28.1.2",
+    "jest-expo": "^49.0.0",
     "nodemon": "^2.0.18",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -105,7 +106,6 @@
   "dependencies": {
     "@react-google-maps/api": "^2.12.0",
     "expo-location": "~15.1.1",
-    "jest-expo": "^48.0.0",
     "supercluster": "^7.1.5"
   }
 }


### PR DESCRIPTION
Based on feedback from https://github.com/teovillanueva/react-native-web-maps/issues/30. Should be pretty low risk :)