### PR TITLE
feat: Added streetViewControl prop to the MapView, this will help to …

### DIFF
--- a/docs/docs/support/map-view.md
+++ b/docs/docs/support/map-view.md
@@ -47,6 +47,7 @@ title: MapView ✅
 | `rotateEnabled`                   | ✅     |                                                                |
 | `scrollEnabled`                   | 🤔     |                                                                |
 | `scrollDuringRotateOrZoomEnabled` | 🤔     |                                                                |
+| `streetViewControl`               | ✅     | Setting this false removes the corner button for street view.  |
 | `pitchEnabled`                    | ✅     |                                                                |
 | `toolbarEnabled`                  | ❌     |                                                                |
 | `cacheEnabled`                    | ❌     |                                                                |

--- a/packages/react-native-web-maps/src/components/map-view.tsx
+++ b/packages/react-native-web-maps/src/components/map-view.tsx
@@ -333,6 +333,7 @@ function _MapView(props: MapViewProps, ref: ForwardedRef<Partial<RNMapView>>) {
           maxZoom: props.maxZoomLevel, // TODO: Normalize value
           scaleControl: props.showsScale,
           styles: props.customMapStyle,
+          streetViewControl: props.streetViewControl,
           ...(props.options || {}),
         }}
       >
@@ -359,6 +360,7 @@ function _MapView(props: MapViewProps, ref: ForwardedRef<Partial<RNMapView>>) {
       props.maxZoomLevel,
       props.showsScale,
       props.customMapStyle,
+      props.streetViewControl,
       props.options,
     ]
   );


### PR DESCRIPTION
With this update, we can now hide the **"Drag To StreetView"** button by using the **streetViewControl** prop and setting it to false. This will get rid of the button that usually appears at the right corner of the screen, giving users a cleaner map interface. I've also added the prop in the documentation. Thanks